### PR TITLE
Use english for babel

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -1,6 +1,6 @@
 \documentclass[runningheads,a4paper]{llncs}
 
-\usepackage[american]{babel}
+\usepackage[english]{babel}
 
 %better font, similar to the default springer font
 %cfr-lm is preferred over lmodern. Reasoning at http://tex.stackexchange.com/a/247543/9075


### PR DESCRIPTION
Even though `american`, `english` and `USenglish` are synonyms for babel package (according to https://tex.stackexchange.com/questions/12775/babel-english-american-usenglish), the llncs document class is prepared to avoid the overriding of certain names (such as "Abstract." -> "Abstract" or "Fig." -> "Figure") when using `english`, but not when using the other 2.