### PR TITLE
Leave runningheads optional

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -1,4 +1,4 @@
-\documentclass[runningheads,a4paper]{llncs}
+\documentclass[a4paper]{llncs} % If you want to add therunning heads, add the option: runningheads
 
 \usepackage[american]{babel}
 


### PR DESCRIPTION
As we wanted them just for the paper to be camera-ready.
