### PR TITLE
Figure name is already in the document class

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -96,8 +96,6 @@ pdfstartview=Fit
 %Nice formats for \cref
 \crefname{section}{Sect.}{Sect.}
 \Crefname{section}{Section}{Sections}
-\crefname{figure}{Fig.}{Fig.}
-\Crefname{figure}{Figure}{Figures}
 
 \usepackage{xspace}
 %\newcommand{\eg}{e.\,g.\xspace}


### PR DESCRIPTION
It's already abbreviated when using `\cref` and not abbreviated when using `\Cref`. This occurs when using `english` babel.