### PR TITLE
Remove option nameinlink from cleveref

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -92,7 +92,7 @@ pdfstartview=Fit
 \newcommand{\todo}[1]{\commentatside{#1}}
 
 %enable \cref{...} and \Cref{...} instead of \ref: Type of reference included in the link
-\usepackage[capitalise,nameinlink]{cleveref}
+\usepackage[capitalise]{cleveref}
 %Nice formats for \cref
 \crefname{section}{Sect.}{Sect.}
 \Crefname{section}{Section}{Sections}


### PR DESCRIPTION
LNCS doesn't use links inside the reference name.