### PR TITLE
Port eloquenza's changes

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -15,4 +15,4 @@ $pdf_mode = 1;
 $bibtex_use = 2;
 
 #remove more files than in the default configuration
-@generated_exts = qw(acn acr alg aux code ist fls glg glo gls idx ind lof lot out thm toc tpt);
+@generated_exts = qw(acn acr alg aux code ist fls glg glo gls idx ind lof lot out thm toc tpt upa upb synctex);

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+sources = paper.tex
+llncs-class = llncs.cls
+
+.PHONY: clean reformat split-sentences indent
+
+compile: $(sources)
+	latexmk $(sources)
+
+$(sources): $(llncs-class)
+$(llncs-class): download
+
+download:
+ifeq (,$(wildcard ./$(llncs-class)))
+	./download-llncs-files-from-springer.sh
+endif
+
+format:
+	latexindent -l -s -sl -w $(sources)
+
+indent:
+	latexindent -y="indentPreamble:1,defaultIndent:'  '" -m -w $(sources)
+
+split-sentences:
+	latexindent -m -l -s -sl -w $(sources)
+
+clean:
+	latexmk -c

--- a/download-llncs-files-from-springer.sh
+++ b/download-llncs-files-from-springer.sh
@@ -1,2 +1,21 @@
 wget ftp://ftp.springernature.com/cs-proceeding/llncs/llncs2e.zip
 unzip -o llncs2e.zip
+# Archive content:
+#    fig1.eps
+#    history.txt
+#    llncs.cls
+#    llncsdoc.pdf
+#    readme.txt
+#    samplepaper.tex
+#    splncs04.bst
+# Only the llncs.cls is actually needed, therefore we are deleting the rest.
+rm fig1.eps
+rm history.txt
+rm llncsdoc.pdf
+rm readme.txt
+rm samplepaper.tex
+rm splncs04.bst
+echo "Removed unneeded files: fig1.eps, history.txt, llncsdoc.pdf, readme.txt, samplepaper.tex, splncs04.bst"
+# Remove the archive as that is also not needed anymore
+rm llncs2e.zip
+echo "Removed the archive: llnc2e.zip"


### PR DESCRIPTION
I found @eloquenza's fork using https://useful-forks.github.io/?repo=latextemplates%2FLNCS and found interesting commits. This cherry-picks these changes by @eloquenza to here. I could not use all changes. Following are not ported:

- `*.pdf` not ignored, because I create figures for LaTeX in the pdf format (to have scalable images)
- Changes in README.md have to go into https://github.com/latextemplates/generator-latex-template/blob/main/generators/app/templates/README.en.md.
- Split configurations is a huger todo for the template generator, thus I created https://github.com/latextemplates/generator-latex-template/issues/53

I finally did `git merge -s ours eloquenza/master` to have the fork.

Next steps port the updates back to the generator: https://github.com/latextemplates/generator-latex-template/issues/54