### PR TITLE
Update LTG

### DIFF
--- a/.aspell.conf
+++ b/.aspell.conf
@@ -10,6 +10,8 @@ add-tex-command FXRegisterAuthor ppp
 add-tex-command PassOptionsToPackage pp
 add-tex-command RequirePackage op
 add-tex-command begin pop
+add-tex-command BeginAccSupp p
+add-tex-command EndAccSupp p
 add-tex-command bibliographystyle p
 add-tex-command boolfalse p
 add-tex-command captionsetup op

--- a/.aspell.conf
+++ b/.aspell.conf
@@ -11,6 +11,7 @@ add-tex-command PassOptionsToPackage pp
 add-tex-command RequirePackage op
 add-tex-command begin pop
 add-tex-command bibliographystyle p
+add-tex-command boolfalse p
 add-tex-command captionsetup op
 add-tex-command citep op
 add-tex-command citet op
@@ -19,6 +20,7 @@ add-tex-command cref p
 add-tex-command embedfile op
 add-tex-command frac pp
 add-tex-command hypersetup p
+add-tex-command indexnames p
 add-tex-command label p
 add-tex-command languageshorthands p
 add-tex-command lstset ppppppppppppppppppppppp
@@ -26,6 +28,8 @@ add-tex-command mathit p
 add-tex-command newcommand pp
 add-tex-command oname p
 add-tex-command patchcmd ppp
+add-tex-command printnames p
+add-tex-command printtext op
 add-tex-command renewcommand pp
 add-tex-command restoresymbol pp
 add-tex-command savesymbol p
@@ -38,6 +42,7 @@ add-tex-command tcbinputlisting ppppppppppppppppppppppp
 add-tex-command texttt p
 add-tex-command tikzpicture op
 add-tex-command tikzset p
+add-tex-command usebibmacro p
 add-tex-command usemintedstyle p
 add-tex-command usepackage oooooop
 add-tex-command usetikzlibrary p

--- a/.aspell.conf
+++ b/.aspell.conf
@@ -16,6 +16,7 @@ add-tex-command citep op
 add-tex-command citet op
 add-tex-command color p
 add-tex-command cref p
+add-tex-command embedfile op
 add-tex-command frac pp
 add-tex-command hypersetup p
 add-tex-command label p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Fixed
 
+- The README links for the original LNCS demonstration and documentation (`llncs-dem.pdf`, `llncs-doc.pdf`) were dead: the documentation now points to the CTAN-hosted `llncsdoc.pdf`; the `llncs.dem` demonstration is no longer distributed, so the README points to `samplepaper.tex` in Springer's proceedings-templates zip instead. [#29](https://github.com/latextemplates/lncs-enhanced/issues/29)
 - arXiv uploads no longer fail with "! I can't find file `clmr28t10+20`": `paper.tex` now starts with `\ifdefined\pdfoutput\pdfoutput=1\fi`, which makes arXiv use `pdflatex` instead of DVI-producing `latex`. See the README section "Final submission". [lncs-enhanced#44](https://github.com/latextemplates/lncs-enhanced/issues/44)
 
 ## [2026-06-30]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 - The compiled PDF now embeds `paper.bib`, so the reference data can be extracted from the PDF (e.g., with JabRef).
 
+### Fixed
+
+- arXiv uploads no longer fail with "! I can't find file `clmr28t10+20`": `paper.tex` now starts with `\ifdefined\pdfoutput\pdfoutput=1\fi`, which makes arXiv use `pdflatex` instead of DVI-producing `latex`. See the README section "Final submission". [lncs-enhanced#44](https://github.com/latextemplates/lncs-enhanced/issues/44)
+
 ## [2026-06-30]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 - LuaLaTeX builds avoid a lone short word as the last line of a paragraph (`impnattypo` with its `lastparline` feature; pdfLaTeX builds are unaffected). [lncs-enhanced#16](https://github.com/latextemplates/lncs-enhanced/issues/16)
 - The example content demonstrates the theorem-like environments of the `llncs` class (`definition`, `proposition`, `lemma`, `theorem`, `proof`, `corollary`, `example`) with a displayed, referenced equation -- the paper example now covers what the retired upstream `llncs.dem` demonstration showed. [#29](https://github.com/latextemplates/lncs-enhanced/issues/29)
-- The README documents biblatex support (`--bibtextool=biblatex`, using the `biblatex-lncs` style) and the new `--authoryear` generator switch for author-year citations, answering the long-standing `citeauthoryear` question. [#23](https://github.com/latextemplates/lncs-enhanced/issues/23)
+- The README documents biblatex support (`--bibtextool=biblatex`, using the `biblatex-lncs` style) and the new `--authoryear` generator switch for author-year citations, answering the long-standing `citeauthoryear` question. [#23](https://github.com/latextemplates/lncs-enhanced/issues/23) [#3](https://github.com/latextemplates/lncs-enhanced/issues/3)
 - The compiled PDF now embeds `paper.bib`, so the reference data can be extracted from the PDF (e.g., with JabRef).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- The example content demonstrates the theorem-like environments of the `llncs` class (`definition`, `proposition`, `lemma`, `theorem`, `proof`, `corollary`, `example`) with a displayed, referenced equation -- the paper example now covers what the retired upstream `llncs.dem` demonstration showed. [#29](https://github.com/latextemplates/lncs-enhanced/issues/29)
 - The README documents biblatex support (`--bibtextool=biblatex`, using the `biblatex-lncs` style) and the new `--authoryear` generator switch for author-year citations, answering the long-standing `citeauthoryear` question. [#23](https://github.com/latextemplates/lncs-enhanced/issues/23)
 - The compiled PDF now embeds `paper.bib`, so the reference data can be extracted from the PDF (e.g., with JabRef).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- LuaLaTeX builds avoid a lone short word as the last line of a paragraph (`impnattypo` with its `lastparline` feature; pdfLaTeX builds are unaffected). [lncs-enhanced#16](https://github.com/latextemplates/lncs-enhanced/issues/16)
 - The example content demonstrates the theorem-like environments of the `llncs` class (`definition`, `proposition`, `lemma`, `theorem`, `proof`, `corollary`, `example`) with a displayed, referenced equation -- the paper example now covers what the retired upstream `llncs.dem` demonstration showed. [#29](https://github.com/latextemplates/lncs-enhanced/issues/29)
 - The README documents biblatex support (`--bibtextool=biblatex`, using the `biblatex-lncs` style) and the new `--authoryear` generator switch for author-year citations, answering the long-standing `citeauthoryear` question. [#23](https://github.com/latextemplates/lncs-enhanced/issues/23)
 - The compiled PDF now embeds `paper.bib`, so the reference data can be extracted from the PDF (e.g., with JabRef).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- The README now links the [latex-snippets site](https://latextemplates.github.io/latex-snippets/) near the top, so you can inspect the source snippets this template is assembled from.
 - Soft-wrapped lines in code listings now show a gray hook arrow (↪) at the start of each continuation line, so they are distinguishable from real line breaks; the arrow is not copied when you select the code from the PDF.
 - The "Examples" section with the rendered example-PDF links now appears right below the title, before "Usage", so you see the output first.
 - Opt-in rectangular ("block") paragraphs: uncomment `\rectangularparagraphstrue` in the preamble to stretch every paragraph's last line to the full column width (off by default; see the comment in `paper.tex` for the copy-fitting trade-off).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- The Overleaf note now states the template is based on TeX Live 2025 (was 2024), matching Overleaf's current TeX Live.
 - The README now links the [latex-snippets site](https://latextemplates.github.io/latex-snippets/) near the top, so you can inspect the source snippets this template is assembled from.
 - Soft-wrapped lines in code listings now show a gray hook arrow (↪) at the start of each continuation line, so they are distinguishable from real line breaks; the arrow is not copied when you select the code from the PDF.
 - The "Examples" section with the rendered example-PDF links now appears right below the title, before "Usage", so you see the output first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://calver.org/).
 
+## [Unreleased]
+
+### Added
+
+- The compiled PDF now embeds `paper.bib`, so the reference data can be extracted from the PDF (e.g., with JabRef).
+
 ## [2026-06-30]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- Opt-in rectangular ("block") paragraphs: uncomment `\rectangularparagraphstrue` in the preamble to stretch every paragraph's last line to the full column width (off by default; see the comment in `paper.tex` for the copy-fitting trade-off).
 - LuaLaTeX builds avoid a lone short word as the last line of a paragraph (`impnattypo` with its `lastparline` feature; pdfLaTeX builds are unaffected). [lncs-enhanced#16](https://github.com/latextemplates/lncs-enhanced/issues/16)
 - The example content demonstrates the theorem-like environments of the `llncs` class (`definition`, `proposition`, `lemma`, `theorem`, `proof`, `corollary`, `example`) with a displayed, referenced equation -- the paper example now covers what the retired upstream `llncs.dem` demonstration showed. [#29](https://github.com/latextemplates/lncs-enhanced/issues/29)
 - The README documents biblatex support (`--bibtextool=biblatex`, using the `biblatex-lncs` style) and the new `--authoryear` generator switch for author-year citations, answering the long-standing `citeauthoryear` question. [#23](https://github.com/latextemplates/lncs-enhanced/issues/23) [#3](https://github.com/latextemplates/lncs-enhanced/issues/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- Soft-wrapped lines in code listings now show a gray hook arrow (↪) at the start of each continuation line, so they are distinguishable from real line breaks; the arrow is not copied when you select the code from the PDF.
 - The "Examples" section with the rendered example-PDF links now appears right below the title, before "Usage", so you see the output first.
 - Opt-in rectangular ("block") paragraphs: uncomment `\rectangularparagraphstrue` in the preamble to stretch every paragraph's last line to the full column width (off by default; see the comment in `paper.tex` for the copy-fitting trade-off).
 - LuaLaTeX builds avoid a lone short word as the last line of a paragraph (`impnattypo` with its `lastparline` feature; pdfLaTeX builds are unaffected). [lncs-enhanced#16](https://github.com/latextemplates/lncs-enhanced/issues/16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- The "Examples" section with the rendered example-PDF links now appears right below the title, before "Usage", so you see the output first.
 - Opt-in rectangular ("block") paragraphs: uncomment `\rectangularparagraphstrue` in the preamble to stretch every paragraph's last line to the full column width (off by default; see the comment in `paper.tex` for the copy-fitting trade-off).
 - LuaLaTeX builds avoid a lone short word as the last line of a paragraph (`impnattypo` with its `lastparline` feature; pdfLaTeX builds are unaffected). [lncs-enhanced#16](https://github.com/latextemplates/lncs-enhanced/issues/16)
 - The example content demonstrates the theorem-like environments of the `llncs` class (`definition`, `proposition`, `lemma`, `theorem`, `proof`, `corollary`, `example`) with a displayed, referenced equation -- the paper example now covers what the retired upstream `llncs.dem` demonstration showed. [#29](https://github.com/latextemplates/lncs-enhanced/issues/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From 2022-03-01 onwards, versioning is done using [Calendar Versioning](https://
 
 ### Added
 
+- The README documents biblatex support (`--bibtextool=biblatex`, using the `biblatex-lncs` style) and the new `--authoryear` generator switch for author-year citations, answering the long-standing `citeauthoryear` question. [#23](https://github.com/latextemplates/lncs-enhanced/issues/23)
 - The compiled PDF now embeds `paper.bib`, so the reference data can be extracted from the PDF (e.g., with JabRef).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ On the command line, there are additional features:
 - `latexmk -C` or `make clean` for cleaning up
 - `make format` to reformat the `.tex` files (one sentence per line and indent)
 - `make aspell` for interactive spell checking
-- `make stand`: Creates a new PDF with the current status of the thesis.
+- `make stand`: Creates a new PDF with the current status of the document.
 - `make view`: Opens the configured viewer
 - `make mrproper`: Cleans up and removes also editor backup files.
 
@@ -209,7 +209,7 @@ Alternatively, just copy and paste the contents of the [vscode.settings.json](vs
 
 You can manually trigger compilation by hitting the green button in the extension or using other methods provided by LaTeX Workshop.
 
-Please remove the magic comments (`% !TeX program ...`) at the top of the `main-....tex` file.
+Please remove the magic comments (`% !TeX program ...`) at the top of the `paper.tex` file.
 Although [LaTeX-Workshop supports magic comments](https://github.com/James-Yu/LaTeX-Workshop/blob/master/README.md#magic-comments), it currently does not work reliably.
 Without the magic comments, compilation works.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Please be aware that this template is optimized for overleaf, which is based on TeXLive 2024.
 In case you are running a later TeXLive version (or use MiKTeX), please regenerate the template with the help of the [latex template generator].
 
+The LaTeX snippets this template is assembled from can be inspected at <https://latextemplates.github.io/latex-snippets/>.
+
 ## Examples
 
 - [paper.pdf](https://latextemplates.github.io/lncs-enhanced/paper.pdf) - normal paper.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ There is no need to adjust the packages or to remove some of them.
 This might lead to undesired results such as hyperlinks not working any more or no good microtypographic features.
 In case you think, a package needs to be altered or added, feel free to open an issue.
 
+## Final submission
+
+The compiled PDF embeds the `paper.bib` file (via the [embedfile](https://ctan.org/pkg/embedfile) package), so readers can extract the reference data from the PDF, e.g., with JabRef via "Import into library".
+Some publishers' final-submission checks (e.g., IEEE PDF eXpress or PDF/A validation) reject PDFs containing file attachments.
+If your submission system complains, comment out the `\embedfile` line in `paper.tex` for the camera-ready version.
+
 ## Tool hints
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -439,8 +439,7 @@ Just answer "(a) allow for this document" and it will work.
 ## Further information
 
 - tex.stackexchange.com questions regarding LNCS: <https://tex.stackexchange.com/questions/tagged/lncs>
-- Original LNCS demonstration (without the improvements): [llncs-dem.pdf](llncs-dem.pdf)
-- Original LNCS documentation (without the improvements): [llncs-doc.pdf](llncs-doc.pdf)
+- Original LNCS documentation (without the improvements): [llncsdoc.pdf](https://mirrors.ctan.org/macros/latex/contrib/llncs/llncsdoc.pdf) from the [llncs CTAN package](https://ctan.org/pkg/llncs). The old `llncs.dem` demonstration is no longer part of that package; the official sample paper (`samplepaper.tex`) is contained in Springer's [LaTeX2e Proceedings Templates (zip)](https://www.springer.com/gp/computer-science/lncs/conference-proceedings-guidelines).
 - Other templates: <https://latextemplates.github.io/>
 - For German users, go to <https://texfragen.de/>.
 - Frank Mittelbach with Ulrike Fischer: [The LaTeX Companion](https://www.latex-project.org/news/2023/03/17/TLC3/) is the ultimate guide for LaTeX: The authors went through all packages offered by [CTAN](https://ctan.org/), selected the most promising ones, described them, and provide minimal working example for each of it.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ The compiled PDF embeds the `paper.bib` file (via the [embedfile](https://ctan.o
 Some publishers' final-submission checks (e.g., IEEE PDF eXpress or PDF/A validation) reject PDFs containing file attachments.
 If your submission system complains, comment out the `\embedfile` line in `paper.tex` for the camera-ready version.
 
+### arXiv
+
+The first line of `paper.tex` is `\ifdefined\pdfoutput\pdfoutput=1\fi`.
+Keep it when uploading to arXiv: arXiv scans the first lines for `\pdfoutput=1` to decide between `pdflatex` and DVI-producing `latex`.
+Without the line, arXiv falls back to `latex`, which cannot build the modern fonts (they ship without Metafont sources) and aborts with an error such as `! I can't find file 'clmr28t10+20'`.
+See [this question on TeX.SE](https://tex.stackexchange.com/q/584702/9075) for details.
+
 ## Tool hints
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Quick start for modern LaTeXing with [LNCS](http://www.springer.com/computer/lncs).
 
-Please be aware that this template is optimized for overleaf, which is based on TeXLive 2024.
+Please be aware that this template is optimized for overleaf, which is based on TeXLive 2025.
 In case you are running a later TeXLive version (or use MiKTeX), please regenerate the template with the help of the [latex template generator].
 
 The LaTeX snippets this template is assembled from can be inspected at <https://latextemplates.github.io/latex-snippets/>.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 Please be aware that this template is optimized for overleaf, which is based on TeXLive 2024.
 In case you are running a later TeXLive version (or use MiKTeX), please regenerate the template with the help of the [latex template generator].
 
+## Examples
+
+- [paper.pdf](https://latextemplates.github.io/lncs-enhanced/paper.pdf) - normal paper.
+- [paper-minted.pdf](https://latextemplates.github.io/lncs-enhanced/paper-minted.pdf) - paper showing minted in action.
+- [paper-newtx.pdf](http://latextemplates.github.io/lncs-enhanced/paper-newtx.pdf) - paper typeset in Times Roman to save some space.
+- [paper-minted-newtx.pdf](http://latextemplates.github.io/lncs-enhanced/paper-minted-newtx.pdf) - paper typeset in Times Roman to save some space.
+
 ## Usage
 
 - `paper.tex` is the main document
@@ -105,13 +112,6 @@ Hints on writing an abstract and thesis by Dirk Fahland.
 Besides the default BibTeX setup (natbib + `splncs04nat`), biblatex is supported: generate with `--bibtextool=biblatex` to use the [biblatex-lncs](https://ctan.org/pkg/biblatex-lncs) style (numeric, mimicking Springer's `splncs04` look, processed with biber).
 
 For **author-year citations** (this template's answer to `llncs`'s `citeauthoryear` option, whose Springer `.bst` files are not part of TeX Live), generate with `--authoryear=true`: this switches to biblatex with the `authoryear` style, so `\citep{key}` renders as "(Author, year)" and `\citet{key}` as "Author (year)".
-
-## Examples
-
-- [paper.pdf](https://latextemplates.github.io/lncs-enhanced/paper.pdf) - normal paper.
-- [paper-minted.pdf](https://latextemplates.github.io/lncs-enhanced/paper-minted.pdf) - paper showing minted in action.
-- [paper-newtx.pdf](http://latextemplates.github.io/lncs-enhanced/paper-newtx.pdf) - paper typeset in Times Roman to save some space.
-- [paper-minted-newtx.pdf](http://latextemplates.github.io/lncs-enhanced/paper-minted-newtx.pdf) - paper typeset in Times Roman to save some space.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ You can run the [latex template generator] to enable the features.
 
 Hints on writing an abstract and thesis by Dirk Fahland.
 
-There is currently no official biblatex support.
-A first step towards that is done at [biblatex-lncs](https://ctan.org/pkg/biblatex-lncs).
+Besides the default BibTeX setup (natbib + `splncs04nat`), biblatex is supported: generate with `--bibtextool=biblatex` to use the [biblatex-lncs](https://ctan.org/pkg/biblatex-lncs) style (numeric, mimicking Springer's `splncs04` look, processed with biber).
+
+For **author-year citations** (this template's answer to `llncs`'s `citeauthoryear` option, whose Springer `.bst` files are not part of TeX Live), generate with `--authoryear=true`: this switches to biblatex with the `authoryear` style, so `\citep{key}` renders as "(Author, year)" and `\citet{key}` as "Author (year)".
 
 ## Examples
 

--- a/Texlivefile
+++ b/Texlivefile
@@ -15,6 +15,7 @@ babel-english
 babel-german
 biber
 biblatex
+biblatex-lncs
 bigfoot
 bigintcalc
 bitset

--- a/Texlivefile
+++ b/Texlivefile
@@ -75,6 +75,7 @@ hyphenex
 ifmtarg
 ifplatform
 iftex
+impnattypo
 inconsolata
 infwarerr
 intcalc

--- a/Texlivefile
+++ b/Texlivefile
@@ -3,6 +3,7 @@ latexindent
 latexmk
 texlogsieve
 
+accsupp
 acmart
 algorithmicx
 algorithms

--- a/Texlivefile
+++ b/Texlivefile
@@ -38,6 +38,7 @@ datetime2-english
 datetime2-german
 dehyph-exptl
 diagbox
+embedfile
 enumitem
 environ
 epstopdf

--- a/Texlivefile
+++ b/Texlivefile
@@ -98,6 +98,11 @@ luatexbase
 luaxml
 ly1
 marginnote
+markdown
+
+csvsimple
+fancyvrb
+verse
 mathdesign
 mathtools
 mfirstuc
@@ -176,3 +181,4 @@ xkeyval
 xpatch
 xstring
 zref
+zref-clever

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -234,6 +234,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -749,6 +749,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Abbildungen}
 
 \begin{ltgexample}

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -147,6 +147,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -237,7 +237,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % zwingt arXiv, diese Datei mit pdflatex statt dem DVI-erzeugenden "latex" zu übersetzen; siehe README-Abschnitt "Final submission"
 % Dieses Template wurde mit der "LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)" getestet
 
 % !TeX spellcheck = de-DE

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -137,6 +137,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -751,7 +751,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -784,7 +784,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper-de-minted-newtx.tex
+++ b/paper-de-minted-newtx.tex
@@ -575,7 +575,7 @@ Schließlich fasst \cref{sec:outlook} die Ergebnisse der Arbeit zusammen und ste
 Eine Beschreibung relevanter wissenschaftlicher Arbeiten mit Bezug zur eigenen Arbeit.
 Der Abschnitt kann je nach Kontext auch an anderer Stelle stehen.
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hinweise}

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -761,6 +761,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Abbildungen}
 
 \begin{ltgexample}

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -149,6 +149,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -246,6 +246,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -159,6 +159,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -587,7 +587,7 @@ Schließlich fasst \cref{sec:outlook} die Ergebnisse der Arbeit zusammen und ste
 Eine Beschreibung relevanter wissenschaftlicher Arbeiten mit Bezug zur eigenen Arbeit.
 Der Abschnitt kann je nach Kontext auch an anderer Stelle stehen.
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hinweise}

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % zwingt arXiv, diese Datei mit pdflatex statt dem DVI-erzeugenden "latex" zu übersetzen; siehe README-Abschnitt "Final submission"
 % Dieses Template wurde mit der "LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)" getestet
 
 % !TeX spellcheck = de-DE

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -763,7 +763,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -796,7 +796,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper-de-minted.tex
+++ b/paper-de-minted.tex
@@ -249,7 +249,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -298,6 +298,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -146,6 +146,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -813,6 +813,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Abbildungen}
 
 \begin{ltgexample}

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % zwingt arXiv, diese Datei mit pdflatex statt dem DVI-erzeugenden "latex" zu übersetzen; siehe README-Abschnitt "Final submission"
 % Dieses Template wurde mit der "LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)" getestet
 
 % !TeX spellcheck = de-DE

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -301,7 +301,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -635,7 +635,7 @@ Schließlich fasst \cref{sec:outlook} die Ergebnisse der Arbeit zusammen und ste
 Eine Beschreibung relevanter wissenschaftlicher Arbeiten mit Bezug zur eigenen Arbeit.
 Der Abschnitt kann je nach Kontext auch an anderer Stelle stehen.
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hinweise}

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -815,7 +815,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -848,7 +848,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -180,6 +180,9 @@
 % Code Listings
 \usepackage{listings}
 
+% accsupp hält den Pfeil (siehe postbreak unten) aus dem kopierten Text heraus
+\usepackage{accsupp}
+
 \definecolor{eclipseStrings}{RGB}{42,0.0,255}
 \definecolor{eclipseKeywords}{RGB}{127,0,85}
 \colorlet{numb}{magenta!60!black}
@@ -231,6 +234,10 @@
   stringstyle=\ttfamily,
   %
   breaklines=true,            % Zeilen werden umbrochen
+  %
+  % Umbrochene Zeilen mit einem grauen Pfeil markieren. Dank accsupp wird der
+  % Pfeil nicht in den kopierten Text übernommen. Quelle: https://tex.stackexchange.com/a/649475/9075
+  postbreak=\raisebox{0ex}[0ex][0ex]{\BeginAccSupp{ActualText={}}\ensuremath{\color{gray}\hookrightarrow\space}\EndAccSupp{}},
   %
   breakatwhitespace=true,
   %

--- a/paper-de-newtx.tex
+++ b/paper-de-newtx.tex
@@ -136,6 +136,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % zwingt arXiv, diese Datei mit pdflatex statt dem DVI-erzeugenden "latex" zu übersetzen; siehe README-Abschnitt "Final submission"
 % Dieses Template wurde mit der "LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)" getestet
 
 % !TeX spellcheck = de-DE

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -158,6 +158,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -192,6 +192,9 @@
 % Code Listings
 \usepackage{listings}
 
+% accsupp hält den Pfeil (siehe postbreak unten) aus dem kopierten Text heraus
+\usepackage{accsupp}
+
 \definecolor{eclipseStrings}{RGB}{42,0.0,255}
 \definecolor{eclipseKeywords}{RGB}{127,0,85}
 \colorlet{numb}{magenta!60!black}
@@ -243,6 +246,10 @@
   stringstyle=\ttfamily,
   %
   breaklines=true,            % Zeilen werden umbrochen
+  %
+  % Umbrochene Zeilen mit einem grauen Pfeil markieren. Dank accsupp wird der
+  % Pfeil nicht in den kopierten Text übernommen. Quelle: https://tex.stackexchange.com/a/649475/9075
+  postbreak=\raisebox{0ex}[0ex][0ex]{\BeginAccSupp{ActualText={}}\ensuremath{\color{gray}\hookrightarrow\space}\EndAccSupp{}},
   %
   breakatwhitespace=true,
   %

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -827,7 +827,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -860,7 +860,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -313,7 +313,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -310,6 +310,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -825,6 +825,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Abbildungen}
 
 \begin{ltgexample}

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -647,7 +647,7 @@ Schließlich fasst \cref{sec:outlook} die Ergebnisse der Arbeit zusammen und ste
 Eine Beschreibung relevanter wissenschaftlicher Arbeiten mit Bezug zur eigenen Arbeit.
 Der Abschnitt kann je nach Kontext auch an anderer Stelle stehen.
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hinweise}

--- a/paper-de.tex
+++ b/paper-de.tex
@@ -148,6 +148,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 % Fuer deutsche Texte: Weniger Silbentrennung durch mehr frei Raum zwischen den Worten
 \setlength{\emergencystretch}{3em}
 

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -152,6 +152,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -716,6 +716,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Figures}
 
 \begin{ltgexample}

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -541,7 +541,7 @@ Finally, a conclusion is drawn and outlook on future work is made (\cref{sec:out
 \section{Related Work}
 \label{sec:relatedwork}
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hints}

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % forces arXiv to process this file with pdflatex instead of DVI-producing "latex"; see README section "Final submission"
 % This template has been tested with LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)
 
 % !TeX spellcheck = en-US

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -235,7 +235,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -232,6 +232,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -142,6 +142,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper-minted-newtx.tex
+++ b/paper-minted-newtx.tex
@@ -718,7 +718,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -751,7 +751,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -154,6 +154,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -164,6 +164,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -244,6 +244,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % forces arXiv to process this file with pdflatex instead of DVI-producing "latex"; see README section "Final submission"
 % This template has been tested with LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)
 
 % !TeX spellcheck = en-US

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -247,7 +247,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -730,7 +730,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -763,7 +763,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -553,7 +553,7 @@ Finally, a conclusion is drawn and outlook on future work is made (\cref{sec:out
 \section{Related Work}
 \label{sec:relatedwork}
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hints}

--- a/paper-minted.tex
+++ b/paper-minted.tex
@@ -728,6 +728,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Figures}
 
 \begin{ltgexample}

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -782,6 +782,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Figures}
 
 \begin{ltgexample}

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -151,6 +151,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -296,6 +296,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % forces arXiv to process this file with pdflatex instead of DVI-producing "latex"; see README section "Final submission"
 % This template has been tested with LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)
 
 % !TeX spellcheck = en-US

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -603,7 +603,7 @@ Finally, a conclusion is drawn and outlook on future work is made (\cref{sec:out
 \section{Related Work}
 \label{sec:relatedwork}
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hints}

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -181,6 +181,9 @@
 % Code Listings
 \usepackage{listings}
 
+% accsupp keeps the soft-wrap arrow (see postbreak below) out of the copied text
+\usepackage{accsupp}
+
 \definecolor{eclipseStrings}{RGB}{42,0.0,255}
 \definecolor{eclipseKeywords}{RGB}{127,0,85}
 \colorlet{numb}{magenta!60!black}
@@ -232,6 +235,10 @@
   stringstyle=\ttfamily,
   %
   breaklines=true,            % Lines are wrapped
+  %
+  % Mark a soft-wrapped line with a gray hook arrow that stays out of the
+  % copied and extracted text. Source: https://tex.stackexchange.com/a/649475/9075
+  postbreak=\raisebox{0ex}[0ex][0ex]{\BeginAccSupp{ActualText={}}\ensuremath{\color{gray}\hookrightarrow\space}\EndAccSupp{}},
   %
   breakatwhitespace=true,
   %

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -141,6 +141,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -299,7 +299,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper-newtx.tex
+++ b/paper-newtx.tex
@@ -784,7 +784,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -817,7 +817,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper.tex
+++ b/paper.tex
@@ -193,6 +193,9 @@
 % Code Listings
 \usepackage{listings}
 
+% accsupp keeps the soft-wrap arrow (see postbreak below) out of the copied text
+\usepackage{accsupp}
+
 \definecolor{eclipseStrings}{RGB}{42,0.0,255}
 \definecolor{eclipseKeywords}{RGB}{127,0,85}
 \colorlet{numb}{magenta!60!black}
@@ -244,6 +247,10 @@
   stringstyle=\ttfamily,
   %
   breaklines=true,            % Lines are wrapped
+  %
+  % Mark a soft-wrapped line with a gray hook arrow that stays out of the
+  % copied and extracted text. Source: https://tex.stackexchange.com/a/649475/9075
+  postbreak=\raisebox{0ex}[0ex][0ex]{\BeginAccSupp{ActualText={}}\ensuremath{\color{gray}\hookrightarrow\space}\EndAccSupp{}},
   %
   breakatwhitespace=true,
   %

--- a/paper.tex
+++ b/paper.tex
@@ -308,6 +308,11 @@
 \patchcmd{\NAT@test}{\else \NAT@nm}{\else \NAT@hyper@{\NAT@nm}}{}{}
 \makeatother
 
+% Embed the bibliography data into the PDF so that readers can extract it
+% (e.g., with JabRef via "Import into library" on the PDF)
+\usepackage{embedfile}
+\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075
 \SetExpansion

--- a/paper.tex
+++ b/paper.tex
@@ -153,6 +153,16 @@
 % Avoid a widow line being split off a displayed equation.
 \displaywidowpenalty=10000
 
+% Avoid a lone short word (or hyphenated fragment) as the last line of a paragraph.
+% LuaTeX only: impnattypo's lastparline feature vetoes the offending line break in
+% each affected paragraph. The package's pdfTeX fallback instead stretches
+% \parfillskip globally, which loosens interword spacing everywhere -- the reason
+% the package was once reverted, see
+% https://github.com/latextemplates/lncs-enhanced/issues/16
+\ifdefined\directlua
+  \usepackage[lastparline]{impnattypo}
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper.tex
+++ b/paper.tex
@@ -796,7 +796,7 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 
 \subsection{Theorem-like Environments and Mathematics}
 
-The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+The \texttt{llncs} class already provides the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
 
 \begin{ltgexample}
 \begin{definition}[Idempotence]
@@ -829,7 +829,7 @@ The \texttt{llncs} class predefines the theorem-like environments \texttt{theore
 \end{corollary}
 
 \begin{example}
-  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+  Trimming spaces in a string is idempotent: \cref{lem:fixed} applies to every already-trimmed string.
 \end{example}
 \end{ltgexample}
 

--- a/paper.tex
+++ b/paper.tex
@@ -1,3 +1,4 @@
+\ifdefined\pdfoutput\pdfoutput=1\fi % forces arXiv to process this file with pdflatex instead of DVI-producing "latex"; see README section "Final submission"
 % This template has been tested with LLNCS DOCUMENT CLASS -- version 2.21 (12-Jan-2022)
 
 % !TeX spellcheck = en-US

--- a/paper.tex
+++ b/paper.tex
@@ -163,6 +163,21 @@
   \usepackage[lastparline]{impnattypo}
 \fi
 
+% --- Rectangular ("block") paragraphs -------------------------------------
+% When enabled, the last line of every paragraph is stretched to the full
+% column width, so each paragraph forms a perfect rectangle. This is
+% demanding typography: paragraphs whose last line is naturally short get
+% visibly wide interword spaces, and good results usually require rewording
+% sentences until every paragraph fits (copy fitting). The lone-word tweak
+% above (impnattypo) becomes irrelevant while this is active.
+% Enable by uncommenting the \rectangularparagraphstrue line:
+\newif\ifrectangularparagraphs
+%\rectangularparagraphstrue
+\ifrectangularparagraphs
+  \setlength{\parfillskip}{0pt}      % force the last line to reach the margin
+  \setlength{\emergencystretch}{3em} % soften overfull lines this may cause
+\fi
+
 \usepackage{graphicx}
 
 % Diagonal lines in a table - http://tex.stackexchange.com/questions/17745/diagonal-lines-in-table-cell

--- a/paper.tex
+++ b/paper.tex
@@ -311,7 +311,7 @@
 % Embed the bibliography data into the PDF so that readers can extract it
 % (e.g., with JabRef via "Import into library" on the PDF)
 \usepackage{embedfile}
-\embedfile[mimetype=application/x-bibtex,desc={BibTeX entries of all references}]{paper.bib}
+\embedfile[mimetype=application/x-bibtex,desc=BibTeX entries of all references]{paper.bib}
 
 % Prepare more space-saving rendering of the bibliography
 % Source: https://tex.stackexchange.com/a/280936/9075

--- a/paper.tex
+++ b/paper.tex
@@ -794,6 +794,45 @@ Cleveref demonstration: Cref at beginning of sentence, cref in all other cases.
 \Cref{sec:ex:cref} shows a simple fact, although \cref{sec:ex:cref} could also show something else.
 \end{ltgexample}
 
+\subsection{Theorem-like Environments and Mathematics}
+
+The \texttt{llncs} class predefines the theorem-like environments \texttt{theorem}, \texttt{proposition}, \texttt{lemma}, \texttt{corollary}, \texttt{definition}, \texttt{example}, \texttt{exercise}, \texttt{note}, \texttt{problem}, \texttt{question}, \texttt{remark}, and \texttt{solution} as well as the unnumbered \texttt{proof} environment -- no additional package is required.
+
+\begin{ltgexample}
+\begin{definition}[Idempotence]
+  An operation $f$ is \emph{idempotent} if $f(f(x)) = f(x)$ holds for all inputs $x$.
+\end{definition}
+
+\begin{proposition}
+  The identity operation is idempotent.
+\end{proposition}
+
+\begin{lemma}\label{lem:fixed}
+  An idempotent operation fixes every element of its image.
+\end{lemma}
+
+\begin{theorem}\label{thm:idempotent-composition}
+  If two idempotent operations $f$ and $g$ commute, their composition $f \circ g$ is idempotent.
+\end{theorem}
+
+\begin{proof}
+  Since $f$ and $g$ commute and are idempotent,
+  \begin{equation}
+    (f \circ g)\bigl((f \circ g)(x)\bigr) = f\bigl(f(g(g(x)))\bigr) = f(g(x)) = (f \circ g)(x).
+    \label{eq:idempotent-composition}
+  \end{equation}
+  \qed
+\end{proof}
+
+\begin{corollary}
+  Applying $f \circ g$ a second time yields no further change, as \cref{eq:idempotent-composition} shows.
+\end{corollary}
+
+\begin{example}
+  Normalizing whitespace in a string is idempotent: \cref{lem:fixed} applies to every already-normalized string.
+\end{example}
+\end{ltgexample}
+
 \subsection{Figures}
 
 \begin{ltgexample}

--- a/paper.tex
+++ b/paper.tex
@@ -615,7 +615,7 @@ Finally, a conclusion is drawn and outlook on future work is made (\cref{sec:out
 \section{Related Work}
 \label{sec:relatedwork}
 
-Winery~\cite{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
+Winery~\citep{Winery} is a graphical \textcomment{modeling}{modeling with one ``l'', because of American English} tool.
 The whole idea of TOSCA is explained by \citet{Binz2009}.
 
 \section{LaTeX Hints}


### PR DESCRIPTION
Regenerated from the current generator `refine-ltg` cycle. Highlights for this template: the PDF embeds `paper.bib`; `\pdfoutput=1` guard for arXiv uploads; real biblatex support (`biblatex-lncs`) and the new `--authoryear` generator switch; theorem-environment examples covering the retired `llncs.dem`; fixed llncs documentation links; no more lone words on paragraph-final lines (LuaLaTeX).

Fixes #3
Fixes #16
Fixes #23
Fixes #29
Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)